### PR TITLE
Agregado de argumento para utilización de tokens activos

### DIFF
--- a/src/pyRofex/clients/rest_rfx.py
+++ b/src/pyRofex/clients/rest_rfx.py
@@ -20,7 +20,7 @@ class RestClient:
     For more information about the API go to: https://apihub.primary.com.ar/assets/docs/Primary-API.pdf
     """
 
-    def __init__(self, environment):
+    def __init__(self, environment, active_token=None):
         """Initialization of the Client.
 
         :param environment: the environment that will be associated with the client.
@@ -31,7 +31,11 @@ class RestClient:
         self.environment = globals.environment_config[environment]
 
         # Get the authentication Token.
-        self.update_token()
+        if not active_token:
+            self.update_token()
+        else:
+            self.environment["token"] = active_token
+            self.environment["initialized"] = True
 
     def get_trade_history(self, ticker, start_date, end_date, market):
         """Makes a request to the API and get trade history for the instrument.

--- a/src/pyRofex/service.py
+++ b/src/pyRofex/service.py
@@ -22,7 +22,7 @@ from .components.enums import Market
 # ######################################################
 
 
-def initialize(user, password, account, environment, proxies=None, ssl_opt=None):
+def initialize(user, password, account, environment, proxies=None, ssl_opt=None, active_token=None):
     """ Initialize the specified environment.
 
      Set the default user, password and account for the environment.
@@ -39,10 +39,12 @@ def initialize(user, password, account, environment, proxies=None, ssl_opt=None)
     :type proxies: dict
     :param ssl_opt: (optional) Dictionary with ssl options for websocket connection.
     :type ssl_opt: dict
+    :param active_token: (optional) Already Active token. If None, it will request new token on authentication.
+    :type active_token: str
     """
     _validate_environment(environment)
     _set_environment_parameters(user, password, account, environment, proxies, ssl_opt)
-    globals.environment_config[environment]["rest_client"] = RestClient(environment)
+    globals.environment_config[environment]["rest_client"] = RestClient(environment, active_token)
     globals.environment_config[environment]["ws_client"] = WebSocketClient(environment)
     set_default_environment(environment)
 


### PR DESCRIPTION
Se actualizó initialize() y RestClient() para aceptar tokens vigentes como argumento y de esta forma evitar estar solicitando nuevamente un token en la inicialización del cliente.